### PR TITLE
Minor parser relaxation for repeated OCR glitches

### DIFF
--- a/lib/rap_sheet_parser/grammars/common_grammar.tt
+++ b/lib/rap_sheet_parser/grammars/common_grammar.tt
@@ -72,7 +72,7 @@ module RapSheetParser
     end
 
     rule arrest_identifier
-      'ARR' stray_punctuation '/' stray_punctuation 'DET' stray_punctuation '/' stray_punctuation 'CITE' w ':' <EventGrammar::ArrestEventIdentifier>
+      'ARR' stray_punctuation '/' stray_punctuation 'DET' stray_punctuation '/' stray_punctuation 'CITE' w (':' / ';') <EventGrammar::ArrestEventIdentifier>
     end
 
     rule custody_identifier

--- a/lib/rap_sheet_parser/text_cleaner.rb
+++ b/lib/rap_sheet_parser/text_cleaner.rb
@@ -1,8 +1,9 @@
 module RapSheetParser
   class TextCleaner
     SUBSTITUTION_PATTERNS = {
-      'CNT:' => /CN[ÍI]:/,
+      'CNT:' => /C(HT|N[ÍI]):/,
       'INFRACTION' => 'TNFRACTION',
+      'CONVICT' => 'COMVICT', # 'convicted', 'conviction' etc.
       'CONV STATUS:' => /CONV STATIS./,
       '-' => '–',
       'RESTN' => 'RESIN',


### PR DESCRIPTION
- 'CHT' for 'CNT'
- 'ARR/DET/CITE;' for 'ARR/DET/CITE:'
- 'COMVICT...' for 'CONVICT...'

Not a huge performance improvement, but hopefully not harmful. Raises performance on my test data set from:
```
Correctly detected 33 out of 46 convictions
Correctly detected 112 out of 115 arrests
Correctly detected 8 out of 8 custody_events
Conviction Accuracy: 71.74%
Arrest Accuracy: 97.39%
Custody Event Accuracy: 100.0%
```
to:
```
Correctly detected 35 out of 46 convictions
Correctly detected 113 out of 115 arrests
Correctly detected 8 out of 8 custody_events
Conviction Accuracy: 76.09%
Arrest Accuracy: 98.26%
Custody Event Accuracy: 100.0%
```
Kindly verify with a broader dataset before merging!